### PR TITLE
Forbidden regex automod

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -6,3 +6,7 @@ moddelmsg:
   notify_channelid: 456456456456
   notify_user_id: 789789789789
   quarantine_roleid: 123456789
+  forbidden_regexes:
+    - "badword1"
+    - "badword2"
+    - "badword3"


### PR DESCRIPTION
## Add forbidden regex automod, quarantine role, and user DM :
- Automatically deletes messages matching forbidden_regexes from config.
- Notifies in the configured log channel with an embed when a message is deleted by automod.
- Adds the Quarantined role to users who trigger automod.
- Sends a DM with an embed to the sanctioned user explaining the sanction and appeal process.
- Each step is wrapped in try/except with logging to prevent crashes and aid debugging.
- Bypass automod for users with a role equal or higher than the bot.
- Added the forbidden_regexes list to demonstrate how to configure forbidden patterns for automod.